### PR TITLE
Modernize BoringSSL vendoring pipeline for tag 0.20260327.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     name: "big-num",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(name: "BigNum", targets: ["BigNum"])
+        .library(name: "BigNum", targets: ["BigNum"]),
         /* This target is used only for symbol mangling. It's added and removed automatically because it emits build warnings. MANGLE_START
             .library(name: "CBigNumBoringSSL", type: .static, targets: ["CBigNumBoringSSL"]),
             MANGLE_END */
@@ -30,5 +30,6 @@ let package = Package(
         ),
         .target(name: "CBigNumBoringSSL"),
         .testTarget(name: "BigNumTests", dependencies: ["BigNum"]),
-    ]
+    ],
+    cxxLanguageStandard: .cxx17
 )

--- a/scripts/VENDORING-0.20260327.0.md
+++ b/scripts/VENDORING-0.20260327.0.md
@@ -1,0 +1,329 @@
+# BoringSSL re-vendoring to tag `0.20260327.0`
+
+This document describes the changes made on the `revendor-pt2` branch (vs
+`main`) to modernize the BoringSSL vendoring pipeline and re-vendor BoringSSL
+at tag `0.20260327.0` (commit `4c91be649fec6c35fb1a3ae0539eaf85e9443ace`).
+
+The previous vendoring was based on pre-C++ BoringSSL (`.c` files, old CMake
+`perlasm()` format, pre-prefix-refactor symbol prefixing). New BoringSSL is
+C++17 with `.cc` / `.cc.inc` / `.c.inc` files and a 4-param `perlasm()`
+directive, and its symbol-prefix helpers were moved into CMake, so both the
+driver scripts and the patches needed significant rework.
+
+This document reflects the full working-tree diff against `main` (committed
+changes plus the currently unstaged modifications on the branch).
+
+## 1. `scripts/vendor-boringssl.sh` — rewritten top to bottom
+
+Rebuilt to mirror swift-nio-ssl's current shape while upgrading to tag
+`0.20260327.0`. The entire file is effectively rewritten; noteworthy specifics:
+
+### Shell hygiene
+- `set -eu` → `set -eou pipefail` (the old script left `pipefail` commented
+  out).
+- `TMPDIR` is now `$(mktemp -d ${HERE}/.boringssl)`. The template has no `X`s,
+  so `mktemp` uses the literal name `.boringssl`; the script does **not**
+  remove this directory itself, so a stale `.boringssl/` must be deleted
+  between runs.
+- Removed the legacy `CROSS_COMPILE_TARGET_LOCATION` / `CROSS_COMPILE_VERSION`
+  globals (the custom destination JSON / CSCIX65G cross-compiler flow is gone).
+- Removed the `getopts 'uk:'` block and the `-c` (clone-latest) / `-k`
+  (keep-temp) flags. The script now always clones fresh and always cleans up.
+
+### Cloning and upstream-util restoration
+- `git clone --depth 1 --branch 0.20260327.0 …` (was an unpinned clone behind
+  a `-c` flag).
+- **Vendored util restore**: BoringSSL removed `util/read_symbols.go`
+  (commit `1842c3eb`) and `util/make_prefix_headers.go` (`b523a5f5`) in
+  Jan 2026 when they moved symbol prefixing into CMake. Our preserved
+  copies in `scripts/vendored-util/` are `cp`'d into `$SRCROOT/util/`
+  immediately after clone, with an inline comment naming both removal
+  commits.
+
+### `PATTERNS` / `EXCLUDES`
+The old hard-coded file-by-file list is replaced with globbing patterns
+matching current BoringSSL layout:
+
+- `include/openssl/*.h`, `include/openssl/*/*.h`
+- `crypto/*.h`, `crypto/*.cc`, `crypto/*/*.{h,cc,S}`,
+  `crypto/*/*/*.{h,cc,cc.inc,inc,S}`, `crypto/*/*/*/*.{cc.inc,inc}`
+- `gen/crypto/*.{cc,S}`, `gen/bcm/*.S` (new `gen/` tree added in 0.20260327)
+- `third_party/fiat/*.h`, `third_party/fiat/*.c.inc`,
+  `third_party/fiat/asm/*.S`
+
+The `*.inc` patterns (as distinct from `*.cc.inc`) pick up
+`fips_known_values.inc` under `crypto/fipsmodule/{slhdsa,mlkem,mldsa}/`.
+`EXCLUDES` updated: `example_*.c` → `example_*.cc`.
+
+### Include rewriting
+The `find … | xargs sed` invocation that rewrites `<openssl/…>` to
+`<CBigNumBoringSSL_…>` now:
+- Covers `*.cc.inc` **and** `*.c.inc` (the latter for
+  `third_party/fiat/*.c.inc`).
+- Uses a regex (`([^/>]+/)*`) that preserves subpath prefixes, so
+  `<openssl/experimental/kyber.h>` becomes
+  `<experimental/CBigNumBoringSSL_kyber.h>`.
+- Also rewrites `#include "openssl/…"` (quoted form).
+
+### Header renaming
+Old `find | sed | xargs mv` was replaced with two bash loops:
+
+```sh
+shopt -s nullglob
+for x in *.h;   do mv -- "$x" "CBigNumBoringSSL_${x}"; done
+for x in **/*.h; do mv -- "$x" "${x%/*}/CBigNumBoringSSL_${x##*/}"; done
+shopt -u nullglob
+```
+
+`nullglob` makes the second loop a no-op when `include/` has no subdirs
+(current BoringSSL layout is flat after the `openssl/` flatten, but keeping
+the loop is forward-compat). Also explicitly `rm -rf include/pki` before
+renaming, since we don't ship the PKI headers.
+
+### Patch application order
+Patches are now applied **before** the Linux exec-stack protection step
+(the old ordering was reversed). `patch-2-arm-arch.patch` and
+`patch-3-weak-linking.patch` are kept on disk but **not applied**; the
+latter targets `crypto/mem.c`, which is now `mem.cc` and would not apply.
+
+### Removed legacy steps
+- `go run err_data_generate.go > …/err_data.c`: gone — upstream now ships
+  pre-generated `err_data.cc` under `gen/`.
+- `rm -f crypto/fipsmodule/bcm.c`: gone (no `bcm.c` in current layout;
+  replaced by `rm -rf $DSTROOT/gen` in the initial wipe).
+- Post-mangle `gsed` edit of `include/openssl/base.h` for the i386
+  `OPENSSL_NO_ASM` guard now targets `CBigNumBoringSSL_base.h` (the
+  renamed header) and uses the `$sed` variable rather than hard-coded
+  `gsed`.
+
+### `mangle_symbols`
+Full rewrite to use the modern toolchain:
+
+- Two macOS builds with explicit triples: `x86_64-apple-macosx` and
+  `arm64-apple-macosx`. Previously a single host-native build.
+- iOS build re-enabled: `xcodebuild -sdk iphoneos -scheme CBigNumBoringSSL
+  -destination generic/platform=iOS`, followed by `ar -r` into
+  `libCBigNumBoringSSL-iosarm64.a`. (The old script had this block
+  commented out.)
+- Linux builds now run in Docker — `swift:6.3-noble` images under
+  `--platform linux/arm64` and `linux/amd64`. Replaces the JSON
+  destination-file loop. `-t -i` flags were removed from both `docker run`
+  invocations so the script works without a TTY (CI, pipes).
+- `read_symbols.go` / `make_prefix_headers.go` are invoked from within
+  `$SRCROOT` after a `go mod tidy -modcacherw`, so Go picks up BoringSSL's
+  own `go.mod` rather than falling back to `GOPATH` resolution.
+- Linux archive path pattern changed from `.build/*-unknown-linux/…` to
+  `.build/*-unknown-linux-gnu/…` to match Swift's current triple naming.
+
+### `namespace_inlines`
+Now scans `$1/*` instead of `$1/crypto/*` (current source layout has
+relevant `DEFINE_STACK_OF` / `DEFINE_LHASH_OF` macros in places outside
+`crypto/`, e.g. under `ssl/` were it vendored — matching swift-nio-ssl).
+Uses the `$sed` variable rather than hard-coded `gsed`.
+
+### New function: `mangle_cpp_structures`
+Entirely new (BoringSSL is now C++, so non-namespaced C++ classes whose
+ctors/dtors have unprefixed linker symbols can still collide). Builds for
+macOS, then:
+
+```sh
+nm -gUj …/libCBigNumBoringSSL.a \
+  | c++filt \
+  | grep "::" \
+  | grep -v -e CBigNumBoringSSL -e swift \
+  | cut -d : -f1 \
+  | { grep -v "std$" || true; } \
+  | sed -E -e 's/([^<>]*)(<[^<>]*>)?/\1/' \
+  | sort | uniq
+```
+
+Each resulting type name gets a
+`#define <struct> BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, <struct>)` line
+appended to `CBigNumBoringSSL_boringssl_prefix_symbols.h`.
+
+**Pipefail fix**: on our archive every remaining C++ symbol is in `std::`,
+so the trailing `grep -v "std$"` matches nothing and exits 1. Under
+`set -o pipefail` this was killing the subshell before the `Package.swift`
+revert could run (leaving the file in its mangled state). Wrapping the grep
+in `{ … || true; }` is the fix, with an in-script comment explaining why.
+
+### Modulemap / umbrella
+A `module.modulemap` is now written at the end of the run (the old script
+never emitted one).
+
+## 2. `scripts/build-asm.py` — modernized for new perlasm
+
+- `#!/usr/bin/env python` → `python3`.
+- Dropped the unused `contextlib` import; reordered remaining imports.
+- Whole file reindented from 2-space to 4-space (matches swift-nio-ssl).
+- **New 4-param `perlasm()` parser**: upstream directive is now
+  `perlasm(<name> <arch> <output> <input> [<extra_args>…])`. Parser rejects
+  lines with `< 4` params (was `< 2`) and stores `arch`, `output`, `input`,
+  `extra_args` keys (old keys: `output`, `input`, `extra_args` only).
+- **`WriteAsmFiles` rewritten**: outer loop is now per-`perlasm`, inner
+  loop over `OS_ARCH_COMBOS` filtered by `perlasm['arch']`. Output naming
+  is uniform: `'%s-%s.%s' % (output, osname, asm_ext)`. The old special
+  cases (`-armx32`/`-armx64` substitution, `${ASM_EXT}` replacement, the
+  `ArchForAsmFilename` filename-substring heuristic) are all gone —
+  upstream's explicit `arch` parameter supersedes them.
+- `ArchForAsmFilename()` deleted entirely.
+- `munge_file` now writes via `.format(...).encode()` since `sink` is
+  opened `'wb'`.
+- Python-3 dict semantics: `.iteritems()` → `.items()` at both call sites.
+- Misc whitespace/linting cleanup (E501 `# noqa` markers, trailing-blank
+  trims).
+
+## 3. `scripts/vendored-util/` (new directory, not on `main`)
+
+- `read_symbols.go`, `make_prefix_headers.go` — vendored verbatim from
+  BoringSSL commit `817ab07` (the last pre-removal commit; matches
+  swift-nio-ssl's own pin).
+- Local patch: `read_symbols.go`'s
+  `import "boringssl.googlesource.com/boringssl/util/ar"` was rewritten to
+  `"boringssl.googlesource.com/boringssl.git/util/ar"` to match the Go
+  module rename done in BoringSSL commit `b8291f83a`.
+- `README.md` documents origin, removal commits, rationale, and the
+  single local patch.
+
+## 4. Patches — regenerated against current BoringSSL layout
+
+Same net effect as the old patches, but updated for current line numbers
+and the Apache-2.0 `//` license headers introduced in BoringSSL's
+relicensing:
+
+- `patch-1-inttypes.patch`
+  - Adds `#include <inttypes.h>` to `crypto/hrss/hrss.cc`.
+  - Swaps `<inttypes.h>` → `<sys/types.h>` in
+    `include/CBigNumBoringSSL_bn.h`. Context rebased around the new
+    `IWYU pragma: export` comment on the `CBigNumBoringSSL_base.h`
+    include.
+- `patch-2-inttypes.patch`
+  - Adds `<inttypes.h>` to `crypto/x509/t_x509.cc`. Earlier drafts also
+    patched `CBigNumBoringSSL_bn.h`; that hunk was dropped because
+    patch-1 already does it.
+- `patch-3-more-inttypes.patch`
+  - Adds `<inttypes.h>` to `crypto/evp/print.cc`.
+
+`patch-2-arm-arch.patch` and `patch-3-weak-linking.patch` remain on disk
+but are no longer applied (see §1).
+
+## 5. `Package.swift`
+
+- Added trailing comma after `.library(name: "BigNum", targets: ["BigNum"])`
+  — without it SwiftPM errored with `static member 'library' cannot be
+  used on instance of type 'Product'` once the file was parsed together
+  with the new `cxxLanguageStandard` argument.
+- Added `cxxLanguageStandard: .cxx17` at the `Package` level — new
+  BoringSSL uses C++17 (`std::is_integral_v`, structured bindings, etc.).
+- `MANGLE_START` / `MANGLE_END` markers and target/products structure are
+  unchanged.
+
+## 6. `Sources/CBigNumBoringSSL/*` (regenerated, unstaged)
+
+Full re-vendoring of BoringSSL at commit
+`4c91be649fec6c35fb1a3ae0539eaf85e9443ace` (tag `0.20260327.0`). This
+replaces the old `.c` / `.h`-only layout with `.cc` / `.cc.inc` / `.c.inc`
+sources plus BoringSSL's new `CBigNumBoringSSL_prefix_symbols.h` (the
+`#pragma redefine_extname`-based prefixing), a refreshed umbrella header,
+module map, and `hash.txt`. These changes are currently untracked/unstaged;
+committing them is the final step before landing the branch.
+
+## 7. `Sources/BigNum/BigNum.swift` — drop the `CBigNumBoringSSL_` prefix
+
+BoringSSL's new prefixing scheme uses `#pragma redefine_extname`, which
+rewrites only the *linker* symbol. At the C source level, identifiers stay
+unprefixed, so Swift's clang importer sees them as `BN_CTX_new`,
+`BN_is_prime_ex`, `OPENSSL_free`, etc. — not
+`CBigNumBoringSSL_BN_CTX_new` and friends. Applied
+`gsed -i 's/CBigNumBoringSSL_//g' Sources/BigNum/BigNum.swift`; all 23
+unit tests pass. (Unstaged.)
+
+## How to re-run the vendoring
+
+```sh
+# Remove the stale clone dir — the literal mktemp name (.boringssl)
+# persists between runs and blocks the next clone:
+rm -rf .boringssl
+
+# Make sure Package.swift is in the un-mangled pre-run state, i.e.:
+#     /* … MANGLE_START
+#         .library(name: "CBigNumBoringSSL", …),
+#         MANGLE_END */
+# If the previous run crashed during mangling you will see
+# `MANGLE_START*/ … /*MANGLE_END` instead — revert manually before re-running.
+
+bash scripts/vendor-boringssl.sh
+```
+
+A successful run takes several minutes: two native macOS builds (x86_64
+and arm64), one iOS arm64 build (xcodebuild), two Linux builds inside
+Docker (`swift:6.3-noble` for arm64 and amd64), symbol extraction via the
+vendored `read_symbols.go`, prefix-header generation via
+`make_prefix_headers.go`, C++ structure mangling via `nm` / `c++filt`,
+patch application, and finally the umbrella header + modulemap
+regeneration.
+
+Docker Desktop must be running for the Linux build phases.
+
+## Build environment
+
+The vendoring run described here was performed on the following machine.
+Anything newer in the same major line should work; older versions may not
+(the script assumes Swift 6.x triple names, `swift:6.3-noble` images, Go
+modules, Python 3 semantics, GNU `sed` extensions, and Xcode 26's iOS
+`-destination generic/platform=iOS` syntax).
+
+### Host
+- **macOS** 26.3.1 (build 25D771280a), Darwin 25.3.0, `arm64` (Apple Silicon).
+- **bash** 5.3.9 (`aarch64-apple-darwin25.1.0`). The header-rename loop uses
+  `shopt -s nullglob` + `**/*.h`; with older bash you'd need `globstar`
+  enabled as well.
+
+### Swift / Xcode
+- **Xcode** 26.3 (build `17C529`) at `/Applications/Xcode.app`
+  (active developer dir via `xcode-select -p`). Required for the iOS arm64
+  build step (`xcodebuild -sdk iphoneos -scheme CBigNumBoringSSL
+  -destination generic/platform=iOS`).
+- **Swift** 6.2.4 (`swiftlang-6.2.4.1.4`, `clang-1700.6.4.2`), default
+  target `arm64-apple-macosx26.0`. Used for the two native macOS builds
+  (`--triple x86_64-apple-macosx` and `arm64-apple-macosx`).
+- **Swift in Docker**: `swift:6.3-noble` (pulled on first run). Used for
+  both `linux/arm64` and `linux/amd64` builds.
+
+### Toolchain utilities invoked by the script
+- **Go** 1.26.2 (`darwin/arm64`). Runs the vendored
+  `scripts/vendored-util/{read_symbols,make_prefix_headers}.go`; `go mod
+  tidy -modcacherw` is executed inside `$SRCROOT` so the clone's own
+  `go.mod` resolves imports.
+- **Perl** 5.34.1 (`darwin-thread-multi-2level`). Drives all BoringSSL
+  `perlasm` scripts via `scripts/build-asm.py`, and is also used for the
+  `#define BORINGSSL_PREFIX` injection into `base.h`.
+- **Python** 3.14.4. Runs `scripts/build-asm.py` (the shebang is
+  `#!/usr/bin/env python3`; the vendoring script also calls `python3`
+  explicitly).
+- **GNU sed** (`gsed`) 4.9. The script selects `gsed` on Darwin and
+  `sed` elsewhere (`sed=gsed` / `sed=sed`); both `MANGLE_START` toggling
+  and the include-rewriting `-r` regex require GNU semantics. Install via
+  `brew install gnu-sed`.
+- **LLVM binutils from Xcode**: `nm` / `c++filt` (both Apple LLVM 17.0.0,
+  shipped with Xcode). `nm -gUj` + `c++filt` drives the
+  `mangle_cpp_structures` pass. `ar` (Apple `ar`, also from Xcode) is used
+  to roll the iOS `.o` into `libCBigNumBoringSSL-iosarm64.a`.
+- **Git** 2.50.1 (Apple Git-155). `git clone --depth 1 --branch
+  0.20260327.0`, plus `git apply` for the three inttypes patches.
+
+### Docker
+- **Docker** 29.3.1 (Docker Desktop), server 29.3.1, Linux OSType, host
+  arch `aarch64`. Used for both Linux Swift builds via
+  `--platform linux/{arm64,amd64}`. QEMU emulation handles `linux/amd64`
+  on the arm64 host (ensure "Use Rosetta for x86_64/amd64 emulation" or
+  `binfmt_misc` is enabled in Docker Desktop).
+
+### Not used by the vendoring script itself, but relevant
+- `swift test` (host macOS) is used to verify the 23 unit tests pass after
+  vendoring.
+- `docker run --rm -v "$(pwd)":/src -w /src --platform linux/arm64
+  swift:6.3-noble swift test` is the same mechanism used to verify Linux
+  parity; it re-uses the same `swift:6.3-noble` image pulled during
+  vendoring.
+

--- a/scripts/build-asm.py
+++ b/scripts/build-asm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the SwiftCrypto open source project
@@ -13,9 +13,8 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-import contextlib
-import subprocess
 import os
+import subprocess
 
 
 # OS_ARCH_COMBOS maps from OS and platform to the OpenSSL assembly "style" for
@@ -45,110 +44,85 @@ NON_PERL_FILES = {
 
 
 def FindCMakeFiles(directory):
-  """Returns list of all CMakeLists.txt files recursively in directory."""
-  cmakefiles = []
+    """Returns list of all CMakeLists.txt files recursively in directory."""
+    cmakefiles = []
 
-  for (path, _, filenames) in os.walk(directory):
-    for filename in filenames:
-      if filename == 'CMakeLists.txt':
-        cmakefiles.append(os.path.join(path, filename))
+    for (path, _, filenames) in os.walk(directory):
+        for filename in filenames:
+            if filename == 'CMakeLists.txt':
+                cmakefiles.append(os.path.join(path, filename))
 
-  return cmakefiles
+    return cmakefiles
 
 
 def ExtractPerlAsmFromCMakeFile(cmakefile):
-  """Parses the contents of the CMakeLists.txt file passed as an argument and
-  returns a list of all the perlasm() directives found in the file."""
-  perlasms = []
-  with open(cmakefile) as f:
-    for line in f:
-      line = line.strip()
-      if not line.startswith('perlasm('):
-        continue
-      if not line.endswith(')'):
-        raise ValueError('Bad perlasm line in %s' % cmakefile)
-      # Remove "perlasm(" from start and ")" from end
-      params = line[8:-1].split()
-      if len(params) < 2:
-        raise ValueError('Bad perlasm line in %s' % cmakefile)
-      perlasms.append({
-          'extra_args': params[2:],
-          'input': os.path.join(os.path.dirname(cmakefile), params[1]),
-          'output': os.path.join(os.path.dirname(cmakefile), params[0]),
-      })
+    """Parses the contents of the CMakeLists.txt file passed as an argument and
+    returns a list of all the perlasm() directives found in the file."""
+    perlasms = []
+    with open(cmakefile) as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith('perlasm('):
+                continue
+            if not line.endswith(')'):
+                raise ValueError('Bad perlasm line in %s' % cmakefile)
+            # Remove "perlasm(" from start and ")" from end
+            params = line[8:-1].split()
+            if len(params) < 4:
+                raise ValueError('Bad perlasm line in %s: %s' % (cmakefile, line))
+            perlasms.append({
+                'arch': params[1],
+                'output': os.path.join(os.path.dirname(cmakefile), params[2]),
+                'input': os.path.join(os.path.dirname(cmakefile), params[3]),
+                'extra_args': params[4:]
+            })
 
-  return perlasms
+    return perlasms
 
 
 def ReadPerlAsmOperations():
-  """Returns a list of all perlasm() directives found in CMake config files in
-  src/."""
-  perlasms = []
-  cmakefiles = FindCMakeFiles('boringssl')
+    """Returns a list of all perlasm() directives found in CMake config files in
+    src/."""
+    perlasms = []
+    cmakefiles = FindCMakeFiles('boringssl')
 
-  for cmakefile in cmakefiles:
-    perlasms.extend(ExtractPerlAsmFromCMakeFile(cmakefile))
+    for cmakefile in cmakefiles:
+        perlasms.extend(ExtractPerlAsmFromCMakeFile(cmakefile))
 
-  return perlasms
+    return perlasms
 
 
 def PerlAsm(output_filename, input_filename, perlasm_style, extra_args):
-  """Runs the a perlasm script and puts the output into output_filename."""
-  base_dir = os.path.dirname(output_filename)
-  if not os.path.isdir(base_dir):
-    os.makedirs(base_dir)
-  subprocess.check_call(
-      ['perl', input_filename, perlasm_style] + extra_args + [output_filename])
-
-
-def ArchForAsmFilename(filename):
-  """Returns the architectures that a given asm file should be compiled for
-  based on substrings in the filename."""
-
-  if 'x86_64' in filename or 'avx2' in filename:
-    return ['x86_64']
-  elif ('x86' in filename and 'x86_64' not in filename) or '586' in filename:
-    return ['x86']
-  elif 'armx' in filename:
-    return ['arm', 'aarch64']
-  elif 'armv8' in filename:
-    return ['aarch64']
-  elif 'arm' in filename:
-    return ['arm']
-  elif 'ppc' in filename:
-    # We aren't supporting ppc here.
-    return []
-  else:
-    raise ValueError('Unknown arch for asm filename: ' + filename)
+    """Runs the a perlasm script and puts the output into output_filename."""
+    base_dir = os.path.dirname(output_filename)
+    if not os.path.isdir(base_dir):
+        os.makedirs(base_dir)
+    subprocess.check_call(
+        ['perl', input_filename, perlasm_style] + extra_args + [output_filename])
 
 
 def WriteAsmFiles(perlasms):
-  """Generates asm files from perlasm directives for each supported OS x
-  platform combination."""
-  asmfiles = {}
-
-  for osarch in OS_ARCH_COMBOS:
-    (osname, arch, perlasm_style, extra_args, asm_ext) = osarch
-    key = (osname, arch)
-    outDir = '%s-%s' % key
+    """Generates asm files from perlasm directives for each supported OS x
+    platform combination."""
+    asmfiles = {}
 
     for perlasm in perlasms:
-      filename = os.path.basename(perlasm['input'])
-      output = perlasm['output']
-      if not output.startswith('boringssl/crypto'):
-        raise ValueError('output missing crypto: %s' % output)
-      output = os.path.join(outDir, output[17:])
-      if output.endswith('-armx.${ASM_EXT}'):
-        output = output.replace('-armx',
-                                '-armx64' if arch == 'aarch64' else '-armx32')
-      output = output.replace('${ASM_EXT}', asm_ext)
+        for (osname, arch, perlasm_style, extra_args, asm_ext) in OS_ARCH_COMBOS:
+            if arch != perlasm['arch']:
+                continue
+            key = (osname, arch)
+            outDir = '%s-%s' % key
 
-      if arch in ArchForAsmFilename(filename):
-        PerlAsm(output, perlasm['input'], perlasm_style,
-                perlasm['extra_args'] + extra_args)
-        asmfiles.setdefault(key, []).append(output)
+            output = perlasm['output']
+            if not output.startswith('boringssl/crypto'):
+                raise ValueError('output missing crypto: %s' % output)
+            output = os.path.join(outDir, output[17:])
+            output = '%s-%s.%s' % (output, osname, asm_ext)
+            per_command_extra_args = extra_args + perlasm['extra_args']
+            PerlAsm(output, perlasm['input'], perlasm_style, per_command_extra_args)
+            asmfiles.setdefault(key, []).append(output)
 
-  return asmfiles
+    return asmfiles
 
 
 def preprocessor_arch_for_arch(arch):
@@ -171,7 +145,7 @@ def preprocessor_platform_for_os(osname):
 
 def asm_target(osname, arch, asm):
     components = asm.split('/')
-    new_components = ["boringssl/crypto"] + components[1:-1] + [components[-1].replace('.S', '.' + osname + '.' + arch + '.S')]
+    new_components = ["boringssl/crypto"] + components[1:-1] + [components[-1].replace('.S', '.' + osname + '.' + arch + '.S')]  # noqa: E501
     return '/'.join(new_components)
 
 
@@ -179,11 +153,11 @@ def munge_file(pp_arch, pp_platform, source_lines, sink):
     """
     Wraps a single assembly file in appropriate defines.
     """
-    sink.write("#if defined(%s) && defined(%s)\n" % (pp_arch, pp_platform))
+    sink.write("#if defined({0}) && defined({1})\n".format(pp_arch, pp_platform).encode())  # noqa: E501
     for line in source_lines:
         sink.write(line)
 
-    sink.write("#endif  // defined(%s) && defined(%s)\n" % (pp_arch, pp_platform))
+    sink.write("#endif  // defined({0}) && defined({1})\n".format(pp_arch, pp_platform).encode())  # noqa: E501
 
 
 def munge_all_files(osname, arch, asms):
@@ -194,11 +168,10 @@ def munge_all_files(osname, arch, asms):
         pp_arch = preprocessor_arch_for_arch(arch)
         pp_platform = preprocessor_platform_for_os(osname)
         target = asm_target(osname, arch, asm)
-        
+
         with open(asm, 'rb') as source:
             with open(target, 'wb') as sink:
                 munge_file(pp_arch, pp_platform, source, sink)
-    
 
 
 def main():
@@ -208,20 +181,20 @@ def main():
     # Now we need to bring over all the .S files, inserting our preprocessor
     # directives along the way. We do this to allow the C preprocessor to make
     # unneeded assembly files vanish.
-    for ((osname, arch), asm_files) in asm_outputs.iteritems():
+    for ((osname, arch), asm_files) in asm_outputs.items():
         munge_all_files(osname, arch, asm_files)
 
-    for ((osname, arch), asm_files) in NON_PERL_FILES.iteritems():
+    for ((osname, arch), asm_files) in NON_PERL_FILES.items():
         for asm_file in asm_files:
-             with open(asm_file, 'rb') as f:
-                 lines = f.readlines()
+            with open(asm_file, 'rb') as f:
+                lines = f.readlines()
 
-             pp_arch = preprocessor_arch_for_arch(arch)
-             pp_platform = preprocessor_platform_for_os(osname)
-             
-             with open(asm_file, 'wb') as sink:
-                 munge_file(pp_arch, pp_platform, lines, sink)
+            pp_arch = preprocessor_arch_for_arch(arch)
+            pp_platform = preprocessor_platform_for_os(osname)
+
+            with open(asm_file, 'wb') as sink:
+                munge_file(pp_arch, pp_platform, lines, sink)
+
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/patch-1-inttypes.patch
+++ b/scripts/patch-1-inttypes.patch
@@ -1,14 +1,23 @@
+diff --git a/Sources/CBigNumBoringSSL/crypto/hrss/hrss.cc b/Sources/CBigNumBoringSSL/crypto/hrss/hrss.cc
+--- a/Sources/CBigNumBoringSSL/crypto/hrss/hrss.cc
++++ b/Sources/CBigNumBoringSSL/crypto/hrss/hrss.cc
+@@ -13,6 +13,7 @@
+ // limitations under the License.
+
+ #include <CBigNumBoringSSL_hrss.h>
++#include <inttypes.h>
+
+ #include <assert.h>
+ #include <stdio.h>
 diff --git a/Sources/CBigNumBoringSSL/include/CBigNumBoringSSL_bn.h b/Sources/CBigNumBoringSSL/include/CBigNumBoringSSL_bn.h
-index c86c1ef..7013140 100644
 --- a/Sources/CBigNumBoringSSL/include/CBigNumBoringSSL_bn.h
 +++ b/Sources/CBigNumBoringSSL/include/CBigNumBoringSSL_bn.h
-@@ -126,7 +126,7 @@
- #include "CBigNumBoringSSL_base.h"
- #include "CBigNumBoringSSL_thread.h"
+@@ -18,7 +18,7 @@
+
+ #include "CBigNumBoringSSL_base.h"   // IWYU pragma: export
 
 -#include <inttypes.h>  // for PRIu64 and friends
 +#include <sys/types.h>
  #include <stdio.h>  // for FILE*
 
  #if defined(__cplusplus)
- 

--- a/scripts/patch-2-inttypes.patch
+++ b/scripts/patch-2-inttypes.patch
@@ -1,0 +1,11 @@
+diff --git a/Sources/CBigNumBoringSSL/crypto/x509/t_x509.cc b/Sources/CBigNumBoringSSL/crypto/x509/t_x509.cc
+--- a/Sources/CBigNumBoringSSL/crypto/x509/t_x509.cc
++++ b/Sources/CBigNumBoringSSL/crypto/x509/t_x509.cc
+@@ -13,6 +13,7 @@
+ // limitations under the License.
+
+ #include <assert.h>
++#include <inttypes.h>
+
+ #include <CBigNumBoringSSL_asn1.h>
+ #include <CBigNumBoringSSL_bio.h>

--- a/scripts/patch-3-more-inttypes.patch
+++ b/scripts/patch-3-more-inttypes.patch
@@ -1,0 +1,11 @@
+diff --git a/Sources/CBigNumBoringSSL/crypto/evp/print.cc b/Sources/CBigNumBoringSSL/crypto/evp/print.cc
+--- a/Sources/CBigNumBoringSSL/crypto/evp/print.cc
++++ b/Sources/CBigNumBoringSSL/crypto/evp/print.cc
+@@ -12,6 +12,7 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+
++#include <inttypes.h>
+ #include <CBigNumBoringSSL_evp.h>
+
+ #include <CBigNumBoringSSL_bio.h>

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -38,23 +38,18 @@
 #      a local copy of the BoringSSL sources in Sources/CBigNumBoringSSL.
 #      Any prior contents of Sources/CBigNumBoringSSL will be deleted.
 #
-set -eu
-#set -eou pipefail
+set -eou pipefail
 
 HERE=$(pwd)
 DSTROOT=Sources/CBigNumBoringSSL
-#TMPDIR=$(mktemp -d /tmp/.workingXXXXXX)
-TMPDIR="${HERE}/.boringssl"
+TMPDIR=$(mktemp -d ${HERE}/.boringssl)
 SRCROOT="${TMPDIR}/src/boringssl.googlesource.com/boringssl"
-CROSS_COMPILE_TARGET_LOCATION="/Library/Developer/Destinations"
-CROSS_COMPILE_VERSION="5.5.2"
 
 # This function namespaces the awkward inline functions declared in OpenSSL
 # and BoringSSL.
 function namespace_inlines {
-    echo "NAMESPACE inlines"
     # Pull out all STACK_OF functions.
-    STACKS=$(grep --no-filename -rE -e "DEFINE_(SPECIAL_)?STACK_OF\([A-Z_0-9a-z]+\)" -e "DEFINE_NAMED_STACK_OF\([A-Z_0-9a-z]+, +[A-Z_0-9a-z:]+\)" "$1/crypto/"* | grep -v '//' | grep -v '#' | gsed -e 's/DEFINE_\(SPECIAL_\)\?STACK_OF(\(.*\))/\2/' -e 's/DEFINE_NAMED_STACK_OF(\(.*\), .*)/\1/')
+    STACKS=$(grep --no-filename -rE -e "DEFINE_(SPECIAL_)?STACK_OF\([A-Z_0-9a-z]+\)" -e "DEFINE_NAMED_STACK_OF\([A-Z_0-9a-z]+, +[A-Z_0-9a-z:]+\)" "$1/"* | grep -v '//' | grep -v '#' | $sed -e 's/DEFINE_\(SPECIAL_\)\?STACK_OF(\(.*\))/\2/' -e 's/DEFINE_NAMED_STACK_OF(\(.*\), .*)/\1/')
     STACK_FUNCTIONS=("call_free_func" "call_copy_func" "call_cmp_func" "new" "new_null" "num" "zero" "value" "set" "free" "pop_free" "insert" "delete" "delete_ptr" "find" "shift" "push" "pop" "dup" "sort" "is_sorted" "set_cmp_func" "deep_copy")
 
     for s in $STACKS; do
@@ -64,7 +59,7 @@ function namespace_inlines {
     done
 
     # Now pull out all LHASH_OF functions.
-    LHASHES=$(grep --no-filename -rE "DEFINE_LHASH_OF\([A-Z_0-9a-z]+\)" "$1/crypto/"* | grep -v '//' | grep -v '#' | grep -v '\\$' | gsed 's/DEFINE_LHASH_OF(\(.*\))/\1/')
+    LHASHES=$(grep --no-filename -rE "DEFINE_LHASH_OF\([A-Z_0-9a-z]+\)" "$1/"* | grep -v '//' | grep -v '#' | grep -v '\\$' | $sed 's/DEFINE_LHASH_OF(\(.*\))/\1/')
     LHASH_FUNCTIONS=("call_cmp_func" "call_hash_func" "new" "free" "num_items" "retrieve" "call_cmp_key" "retrieve_key" "insert" "delete" "call_doall" "call_doall_arg" "doall" "doall_arg")
 
     for l in $LHASHES; do
@@ -85,34 +80,51 @@ function mangle_symbols {
 
         export GOPATH="${TMPDIR}"
 
-        # Begin by building for macOS.
-        swift build --product CBigNumBoringSSL --enable-test-discovery
-        go run "${SRCROOT}/util/read_symbols.go" -out "${TMPDIR}/symbols-macOS.txt" "${HERE}/.build/debug/libCBigNumBoringSSL.a"
+        # Begin by building for macOS. We build for two target triples, Intel
+        # and Apple Silicon.
+        swift build --triple "x86_64-apple-macosx" --product CBigNumBoringSSL
+        swift build --triple "arm64-apple-macosx" --product CBigNumBoringSSL
+        (
+            cd "${SRCROOT}"
+            go mod tidy -modcacherw
+            go run "util/read_symbols.go" -out "${TMPDIR}/symbols-macOS-intel.txt" "${HERE}/.build/x86_64-apple-macosx/debug/libCBigNumBoringSSL.a"
+            go run "util/read_symbols.go" -out "${TMPDIR}/symbols-macOS-as.txt" "${HERE}/.build/arm64-apple-macosx/debug/libCBigNumBoringSSL.a"
+        )
 
         # Now build for iOS. We use xcodebuild for this because SwiftPM doesn't
         # meaningfully support it. Unfortunately we must archive ourselves.
-        #xcodebuild -sdk iphoneos -scheme CBigNumBoringSSL -derivedDataPath "${TMPDIR}/iphoneos-deriveddata"
-        #ar -r "${TMPDIR}/libCBigNumBoringSSL-ios.a" "${TMPDIR}/iphoneos-deriveddata/Build/Products/Debug-iphoneos/CBigNumBoringSSL.o"
-        #go run "${SRCROOT}/util/read_symbols.go" -out "${TMPDIR}/symbols-iOS.txt" "${TMPDIR}/libCBigNumBoringSSL-ios.a"
+        #
+        # If xcodebuild complains about not finding the scheme, make sure there
+        # isn't a .xcodeproj kicking around.
+        xcodebuild -sdk iphoneos -scheme CBigNumBoringSSL -derivedDataPath "${TMPDIR}/iphoneos-deriveddata" -destination generic/platform=iOS
+        ar -r "${TMPDIR}/libCBigNumBoringSSL-iosarm64.a" "${TMPDIR}/iphoneos-deriveddata/Build/Products/Debug-iphoneos/CBigNumBoringSSL.o"
+
+        (
+            cd "${SRCROOT}"
+            go run "util/read_symbols.go" -out "${TMPDIR}/symbols-iOS.txt" "${TMPDIR}/libCBigNumBoringSSL-iosarm64.a"
+        )
 
         # Now cross compile for our targets.
-        # If you have trouble with the script around this point, consider
-        # https://github.com/CSCIX65G/SwiftCrossCompilers to obtain cross
-        # compilers for the architectures we care about.
-        for cc_target in "${CROSS_COMPILE_TARGET_LOCATION}"/*"${CROSS_COMPILE_VERSION}"*.json; do
-            echo "Cross compiling for ${cc_target}"
-            swift build --product CBigNumBoringSSL --destination "${cc_target}" --enable-test-discovery
-        done;
+        docker run --rm --privileged -v"$(pwd)":/src -w/src --platform linux/arm64 swift:6.3-noble \
+            swift build --product CBigNumBoringSSL
+        docker run --rm --privileged -v"$(pwd)":/src -w/src --platform linux/amd64 swift:6.3-noble \
+            swift build --product CBigNumBoringSSL
 
         # Now we need to generate symbol mangles for Linux. We can do this in
         # one go for all of them.
-        go run "${SRCROOT}/util/read_symbols.go" -obj-file-format elf -out "${TMPDIR}/symbols-linux-all.txt" "${HERE}"/.build/*-unknown-linux/debug/libCBigNumBoringSSL.a
+        (
+            cd "${SRCROOT}"
+            go run "util/read_symbols.go" -obj-file-format elf -out "${TMPDIR}/symbols-linux-all.txt" "${HERE}"/.build/*-unknown-linux-gnu/debug/libCBigNumBoringSSL.a
+        )
 
         # Now we concatenate all the symbols together and uniquify it.
         cat "${TMPDIR}"/symbols-*.txt | sort | uniq > "${TMPDIR}/symbols.txt"
 
         # Use this as the input to the mangle.
-        go run "${SRCROOT}/util/make_prefix_headers.go" -out "${HERE}/${DSTROOT}/include/openssl" "${TMPDIR}/symbols.txt"
+        (
+            cd "${SRCROOT}"
+            go run "util/make_prefix_headers.go" -out "${HERE}/${DSTROOT}/include/openssl" "${TMPDIR}/symbols.txt"
+        )
 
         # Remove the product, as we no longer need it.
         $sed -i -e 's/MANGLE_START\*\//MANGLE_START/' -e 's/\/\*MANGLE_END/MANGLE_END/' "${HERE}/Package.swift"
@@ -124,12 +136,51 @@ function mangle_symbols {
     # Now edit the headers again to add the symbol mangling.
     echo "ADDING symbol mangling"
     perl -pi -e '$_ .= qq(\n#define BORINGSSL_PREFIX CBigNumBoringSSL\n) if /#define OPENSSL_HEADER_BASE_H/' "$DSTROOT/include/openssl/base.h"
-    echo "ASSEMBLY"
-    for assembly_file in $(find "$DSTROOT" -name "*.S")
+
+    while IFS= read -r -d '' assembly_file
     do
         $sed -i '1 i #define BORINGSSL_PREFIX CBigNumBoringSSL' "$assembly_file"
-    done
+    done <   <(find "$DSTROOT" -name "*.S" -print0)
     namespace_inlines "$DSTROOT"
+}
+
+
+# BoringSSL includes a few non-namespaced C++ structures. These aren't namespaced because they're exposed
+# in C-land, which doesn't know about the namespacing. Sadly, these structures include constructors and destructors,
+# and if those aren't namespaced we're still able to conflict.
+#
+# This function is responsible for identifying them and manually cleaning them up. We run this only on
+# macOS because we don't believe that the cross-platform architectures will hit any other structures.
+function mangle_cpp_structures {
+    echo "MANGLING C++ structures"
+    (
+        # We need a .a: may as well get SwiftPM to give it to us.
+        # Temporarily enable the product we need.
+        $sed -i -e 's/MANGLE_START/MANGLE_START*\//' -e 's/MANGLE_END/\/*MANGLE_END/' "${HERE}/Package.swift"
+
+        # Build for macOS.
+        swift build --product CBigNumBoringSSL
+
+        # Woah, this is a hell of a command! What does it do?
+        #
+        # The nm command grabs all global defined symbols. We then run the C++ demangler over them and look for methods with '::' in them:
+        # these are C++ methods. We then exclude any that contain CBigNumBoringSSL (as those are already namespaced!) and any that contain swift
+        # (as those were put there by the Swift runtime, not us). This gives us a list of symbols. The following cut command
+        # grabs the type name from each of those (the bit preceding the '::'). Then, we sort and uniqify that list.
+        # Finally, we remove any symbol that ends in std. This gives us all the structures that need to be renamed.
+        # The final `grep -v "std$" || true` is tolerant: if every remaining
+        # symbol is in the std:: namespace (as happens when BoringSSL's own
+        # prefixing has already covered all project-owned C++ symbols), the
+        # grep matches nothing and would otherwise exit 1 under pipefail.
+        structures=$(nm -gUj "$(swift build --show-bin-path)/libCBigNumBoringSSL.a" | c++filt | grep "::" | grep -v -e "CBigNumBoringSSL" -e "swift" | cut -d : -f1 | { grep -v "std$" || true; } | $sed -E -e 's/([^<>]*)(<[^<>]*>)?/\1/' | sort | uniq)
+
+        for struct in ${structures}; do
+            echo "#define ${struct} BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, ${struct})" >> "${DSTROOT}/include/CBigNumBoringSSL_boringssl_prefix_symbols.h"
+        done
+
+        # Remove the product, as we no longer need it.
+        $sed -i -e 's/MANGLE_START\*\//MANGLE_START/' -e 's/\/\*MANGLE_END/MANGLE_END/' "${HERE}/Package.swift"
+    )
 }
 
 case "$(uname -s)" in
@@ -137,6 +188,7 @@ case "$(uname -s)" in
         sed=gsed
         ;;
     *)
+        # shellcheck disable=SC2209
         sed=sed
         ;;
 esac
@@ -148,34 +200,30 @@ if ! hash ${sed} 2>/dev/null; then
     exit 43
 fi
 
-CLONE_LATEST=""
-KEEP_TEMP_FOLDER=""
-
-while getopts 'uk:' option
-do
-    case $option in
-        c) CLONE_LATEST=1 ;;
-        k) KEEP_TEMP_FOLDER=1 ;;
-    esac
-done
-
 echo "REMOVING any previously-vendored BoringSSL code"
 rm -rf $DSTROOT/include
 rm -rf $DSTROOT/ssl
 rm -rf $DSTROOT/crypto
 rm -rf $DSTROOT/third_party
-rm -rf $DSTROOT/err_data.c
+rm -rf $DSTROOT/gen
 
-if [ -n "$CLONE_LATEST" ]; then
-    echo "CLONING boringssl"
-    mkdir -p "$SRCROOT"
-    git clone https://boringssl.googlesource.com/boringssl "$SRCROOT"
-fi
-
+echo "CLONING boringssl"
+mkdir -p "$SRCROOT"
+git clone --depth 1 --branch 0.20260327.0 https://boringssl.googlesource.com/boringssl "$SRCROOT"
 cd "$SRCROOT"
 BORINGSSL_REVISION=$(git rev-parse HEAD)
 cd "$HERE"
 echo "CLONED boringssl@${BORINGSSL_REVISION}"
+
+# BoringSSL removed util/read_symbols.go and util/make_prefix_headers.go in early
+# 2026 (commits b523a5f5 and 1842c3eb) when they integrated symbol prefixing into
+# CMake via audit_symbols.go + delocate. Our mangling pipeline still relies on
+# the old helpers, so we vendor them from commit 817ab07 (the last commit where
+# both files existed, matching what swift-nio-ssl is pinned to) under
+# scripts/vendored-util/ and restore them into the clone before use.
+echo "RESTORING vendored util scripts (removed from BoringSSL upstream)"
+cp "${HERE}/scripts/vendored-util/read_symbols.go" "${SRCROOT}/util/read_symbols.go"
+cp "${HERE}/scripts/vendored-util/make_prefix_headers.go" "${SRCROOT}/util/make_prefix_headers.go"
 
 echo "OBTAINING submodules"
 (
@@ -188,76 +236,44 @@ echo "GENERATING assembly helpers"
     cd "$SRCROOT"
     cd ..
     mkdir -p "${SRCROOT}/crypto/third_party/sike/asm"
-    python "${HERE}/scripts/build-asm.py"
+    python3 "${HERE}/scripts/build-asm.py"
 )
 
 PATTERNS=(
-'include/openssl/aead.h'
-'include/openssl/aes.h'
-'include/openssl/arm_arch.h'
-'include/openssl/asn1.h'
-'include/openssl/base.h'
-'include/openssl/bio.h'
-'include/openssl/bn.h'
-'include/openssl/buf.h'
-'include/openssl/buffer.h'
-'include/openssl/bytestring.h'
-'include/openssl/chacha.h'
-'include/openssl/cipher.h'
-'include/openssl/cpu.h'
-'include/openssl/crypto.h'
-'include/openssl/err.h'
-'include/openssl/ex_data.h'
-'include/openssl/is_boringssl.h'
-'include/openssl/opensslconf.h'
-'include/openssl/mem.h'
-'include/openssl/nid.h'
-'include/openssl/rand.h'
-'include/openssl/sha.h'
-'include/openssl/span.h'
-'include/openssl/stack.h'
-'include/openssl/thread.h'
-'include/openssl/type_check.h'
+'include/openssl/*.h'
+'include/openssl/*/*.h'
 'crypto/*.h'
-'crypto/*.c'
-'crypto/bio/bio.c'
-'crypto/bio/file.c'
-'crypto/bn_extra/convert.c'
-'crypto/bytestring/*.h'
-'crypto/bytestring/*.c'
-'crypto/err/*.c'
-'crypto/err/*.h'
-'crypto/fipsmodule/*.h'
-'crypto/fipsmodule/*.S'
-'crypto/fipsmodule/bn/*.h'
-'crypto/fipsmodule/bn/*.c'
-'crypto/fipsmodule/bn/*/*.c'
-'crypto/fipsmodule/aes/*.h'
-'crypto/fipsmodule/aes/*.c'
-'crypto/fipsmodule/cipher/*.h'
-'crypto/fipsmodule/cipher/cipher.c'
-'crypto/fipsmodule/cipher/e_aes.c'
-'crypto/fipsmodule/modes/*.h'
-'crypto/fipsmodule/modes/*.c'
-'crypto/fipsmodule/rand/*.h'
-'crypto/fipsmodule/rand/*.c'
-'crypto/rand_extra/*.c'
-'crypto/stack/*.c'
+'crypto/*.cc'
+'crypto/*/*.h'
+'crypto/*/*.cc'
+'crypto/*/*.S'
+'crypto/*/*/*.h'
+'crypto/*/*/*.cc'
+'crypto/*/*/*.cc.inc'
+'crypto/*/*/*.inc'
+'crypto/*/*/*.S'
+'crypto/*/*/*/*.cc.inc'
+'crypto/*/*/*/*.inc'
+'gen/crypto/*.cc'
+'gen/crypto/*.S'
+'gen/bcm/*.S'
 'third_party/fiat/*.h'
+'third_party/fiat/*.c.inc'
+'third_party/fiat/asm/*.S'
 )
 
 EXCLUDES=(
 '*_test.*'
 'test_*.*'
 'test'
-'example_*.c'
+'example_*.cc'
 )
 
 echo "COPYING boringssl"
 for pattern in "${PATTERNS[@]}"
 do
   for i in $SRCROOT/$pattern; do
-    path=${i#$SRCROOT}
+    path=${i#"$SRCROOT"}
     dest="$DSTROOT$path"
     dest_dir=$(dirname "$dest")
     mkdir -p "$dest_dir"
@@ -271,28 +287,11 @@ do
   find $DSTROOT -d -name "$exclude" -exec rm -rf {} \;
 done
 
-echo "GENERATING err_data.c"
-(
-    cd "$SRCROOT/crypto/err"
-    go run err_data_generate.go > "${HERE}/${DSTROOT}/crypto/err/err_data.c"
-)
-
-echo "DELETING crypto/fipsmodule/bcm.c"
-rm -f $DSTROOT/crypto/fipsmodule/bcm.c
-
-#echo "FIXING missing include"
-#perl -pi -e '$_ .= qq(\n#include <openssl/cpu.h>\n) if /#include <openssl\/err.h>/' "$DSTROOT/crypto/fipsmodule/ec/p256-x86_64.c"
-
 mangle_symbols
-
-echo "MANGLE done"
-# Removing ASM on 32 bit Apple platforms
-echo "REMOVING assembly on 32-bit Apple platforms"
-gsed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(__APPLE__) && defined(__i386__)\n#define OPENSSL_NO_ASM\n#endif" "$DSTROOT/include/openssl/base.h"
 
 echo "RENAMING header files"
 (
-    # We need to rearrange a coouple of things here, the end state will be:
+    # We need to rearrange a couple of things here, the end state will be:
     # - Headers from 'include/openssl/' will be moved up a level to 'include/'
     # - Their names will be prefixed with 'CBigNumBoringSSL_'
     # - The headers prefixed with 'boringssl_prefix_symbols' will also be prefixed with 'CBigNumBoringSSL_'
@@ -303,28 +302,47 @@ echo "RENAMING header files"
     mv include/openssl/* include/
     rmdir "include/openssl"
 
+    # Now let's remove the pki subdirectory, as we don't need it.
+    rm -rf include/pki
+
     # Now change the imports from "<openssl/X> to "<CBigNumBoringSSL_X>", apply the same prefix to the 'boringssl_prefix_symbols' headers.
-    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" | xargs $sed -i -e 's+include <openssl/+include <CBigNumBoringSSL_+' -e 's+include <boringssl_prefix_symbols+include <CBigNumBoringSSL_boringssl_prefix_symbols+'
+    # shellcheck disable=SC2038
+    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" -or -name "*.cc.inc" -or -name "*.c.inc" | xargs $sed -i -r -e 's#include <openssl/(([^/>]+/)*)(.+.h)>#include <\1CBigNumBoringSSL_\3>#' -e 's+include <boringssl_prefix_symbols+include <CBigNumBoringSSL_boringssl_prefix_symbols+' -e 's#include "openssl/(([^/>]+/)*)(.+.h)"#include "\1CBigNumBoringSSL_\3"#'
 
     # Okay now we need to rename the headers adding the prefix "CBigNumBoringSSL_".
     pushd include
-    find . -name "*.h" | $sed -e "s_./__" | xargs -I {} mv {} CBigNumBoringSSL_{}
+    # nullglob so the second loop is a no-op when there are no subdirectories
+    # (current BoringSSL layout has no subdirs under include/openssl/ by the
+    # time we get here, but older layouts did). Kept for forward-compat.
+    shopt -s nullglob
+    for x in *.h; do mv -- "$x" "CBigNumBoringSSL_${x}"; done
+    for x in **/*.h; do mv -- "$x" "${x%/*}/CBigNumBoringSSL_${x##*/}"; done
+    shopt -u nullglob
+
     # Finally, make sure we refer to them by their prefixed names, and change any includes from angle brackets to quotation marks.
-    find . -name "*.h" | xargs $sed -i -e 's/include "/include "CBigNumBoringSSL_/' -e 's/include <CBigNumBoringSSL_\(.*\)>/include "CBigNumBoringSSL_\1"/'
+    # shellcheck disable=SC2038
+    find . -name "*.h" | xargs $sed -i -r -e 's#include "(([^/"]+/)*)(.+.h)"#include "\1CBigNumBoringSSL_\3"#' -e 's/include <CBigNumBoringSSL_(.*)>/include "CBigNumBoringSSL_\1"/'
     popd
 )
+
+echo "PATCHING BoringSSL"
+git apply "${HERE}/scripts/patch-1-inttypes.patch"
+git apply "${HERE}/scripts/patch-2-inttypes.patch"
+git apply "${HERE}/scripts/patch-3-more-inttypes.patch"
 
 # We need to avoid having the stack be executable. BoringSSL does this in its build system, but we can't.
 echo "PROTECTING against executable stacks"
 (
     cd "$DSTROOT"
+    # shellcheck disable=SC2038
     find . -name "*.S" | xargs $sed -i '$ a #if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,"",%progbits\n#endif\n'
 )
 
-echo "PATCHING BoringSSL"
-git apply "${HERE}/scripts/patch-1-inttypes.patch"
-git apply "${HERE}/scripts/patch-2-arm-arch.patch"
-#git apply "${HERE}/scripts/patch-3-weak-linking.patch"
+mangle_cpp_structures
+
+# Removing ASM on 32 bit Apple platforms
+echo "REMOVING assembly on 32-bit Apple platforms"
+$sed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(__APPLE__) && defined(__i386__)\n#define OPENSSL_NO_ASM\n#endif" "$DSTROOT/include/CBigNumBoringSSL_base.h"
 
 # We need BoringSSL to be modularised
 echo "MODULARISING BoringSSL"
@@ -342,8 +360,13 @@ cat << EOF > "$DSTROOT/include/CBigNumBoringSSL.h"
 #include "CBigNumBoringSSL_err.h"
 #include "CBigNumBoringSSL_rand.h"
 
-
 #endif  // C_BIGNUM_BORINGSSL_H
+EOF
+cat << EOF > "$DSTROOT/include/module.modulemap"
+module CBigNumBoringSSL {
+    umbrella header "CBigNumBoringSSL.h"
+    export *
+}
 EOF
 
 echo "RECORDING BoringSSL revision"
@@ -351,7 +374,4 @@ $sed -i -e "s/BoringSSL Commit: [0-9a-f]\+/BoringSSL Commit: ${BORINGSSL_REVISIO
 echo "This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision ${BORINGSSL_REVISION}" > "$DSTROOT/hash.txt"
 
 echo "CLEANING temporary directory"
-
-if [ -z "$KEEP_TEMP_FOLDER" ]; then
-    rm -rf "${TMPDIR}"
-fi
+rm -rf "${TMPDIR}"

--- a/scripts/vendored-util/README.md
+++ b/scripts/vendored-util/README.md
@@ -1,0 +1,38 @@
+# Vendored BoringSSL util scripts
+
+`read_symbols.go` and `make_prefix_headers.go` are copied verbatim from the
+BoringSSL tree at commit
+[`817ab07ebb53da35afea409ab9328f578492832d`](https://boringssl.googlesource.com/boringssl/+/817ab07ebb53da35afea409ab9328f578492832d/util/).
+
+## Why they live here
+
+BoringSSL removed both files in early 2026 when symbol prefixing was integrated
+directly into its CMake build (via `util/audit_symbols.go` + `delocate`):
+
+- `util/make_prefix_headers.go` — removed in `b523a5f5` (2026-01-16,
+  "Integrate the new way of asm symbol prefixing with CMake").
+- `util/read_symbols.go` — removed in `1842c3eb` (2026-01-19,
+  "Add symbol prefixing validation to CMake").
+
+Our `scripts/vendor-boringssl.sh` still drives symbol mangling the old way
+(running these helpers out-of-tree against the built `.a` archives), so we
+pin copies here and `cp` them into the clone before use. This keeps the
+BoringSSL tag pin (`0.20260327.0`) intact without adopting the new
+CMake-based prefixing flow.
+
+## Updating
+
+If BoringSSL's API stays stable, these files don't need to change. If the
+surface changes (e.g. new object-file formats), update the copies from any
+pre-removal BoringSSL commit and bump the reference above.
+
+The files carry the upstream Apache 2.0 / ISC headers unchanged.
+
+## Local modifications
+
+- `read_symbols.go`: the import of `boringssl.googlesource.com/boringssl/util/ar`
+  was rewritten to `boringssl.googlesource.com/boringssl.git/util/ar` to match
+  the BoringSSL Go module rename done in commit `b8291f83a` ("Add .git hint to
+  Go module name"). The module name at the source commit (`817ab07`) was
+  `boringssl.googlesource.com/boringssl`, but at our pinned tag it is
+  `boringssl.googlesource.com/boringssl.git`.

--- a/scripts/vendored-util/make_prefix_headers.go
+++ b/scripts/vendored-util/make_prefix_headers.go
@@ -1,0 +1,233 @@
+// Copyright 2018 The BoringSSL Authors
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+//go:build ignore
+
+// This program takes a file containing newline-separated symbols, and generates
+// boringssl_prefix_symbols.h, boringssl_prefix_symbols_asm.h, and
+// boringssl_prefix_symbols_nasm.inc. These header files can be used to build
+// BoringSSL with a prefix for all symbols in order to avoid symbol name
+// conflicts when linking a project with multiple copies of BoringSSL; see
+// BUILDING.md for more details.
+package main
+
+// TODO(joshlf): For platforms which support it, use '#pragma redefine_extname'
+// instead of a custom macro. This avoids the need for a custom macro, but also
+// ensures that our renaming won't conflict with symbols defined and used by our
+// consumers (the "HMAC" problem). An example of this approach can be seen in
+// IllumOS' fork of OpenSSL:
+// https://github.com/joyent/illumos-extra/blob/master/openssl1x/sunw_prefix.h
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var out = flag.String("out", ".", "Path to a directory where the outputs will be written")
+
+// Read newline-separated symbols from a file, ignoring any comments started
+// with '#'.
+func readSymbols(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	var ret []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		ret = append(ret, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func writeCHeader(symbols []string, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(`// Copyright 2018 The BoringSSL Authors
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// BORINGSSL_ADD_PREFIX pastes two identifiers into one. It performs one
+// iteration of macro expansion on its arguments before pasting.
+#define BORINGSSL_ADD_PREFIX(a, b) BORINGSSL_ADD_PREFIX_INNER(a, b)
+#define BORINGSSL_ADD_PREFIX_INNER(a, b) a ## _ ## b
+
+`); err != nil {
+		return err
+	}
+
+	for _, symbol := range symbols {
+		if _, err := fmt.Fprintf(f, "#define %s BORINGSSL_ADD_PREFIX(BORINGSSL_PREFIX, %s)\n", symbol, symbol); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeASMHeader(symbols []string, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(`// Copyright 2018 The BoringSSL Authors
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#if !defined(__APPLE__)
+#include <boringssl_prefix_symbols.h>
+#else
+// On iOS and macOS, we need to treat assembly symbols differently from other
+// symbols. The linker expects symbols to be prefixed with an underscore.
+// Perlasm thus generates symbol with this underscore applied. Our macros must,
+// in turn, incorporate it.
+#define BORINGSSL_ADD_PREFIX_MAC_ASM(a, b) BORINGSSL_ADD_PREFIX_INNER_MAC_ASM(a, b)
+#define BORINGSSL_ADD_PREFIX_INNER_MAC_ASM(a, b) _ ## a ## _ ## b
+
+`); err != nil {
+		return err
+	}
+
+	for _, symbol := range symbols {
+		if _, err := fmt.Fprintf(f, "#define _%s BORINGSSL_ADD_PREFIX_MAC_ASM(BORINGSSL_PREFIX, %s)\n", symbol, symbol); err != nil {
+			return err
+		}
+	}
+
+	_, err = fmt.Fprintf(f, "#endif\n")
+	return nil
+}
+
+func writeNASMHeader(symbols []string, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// NASM uses a different syntax from the C preprocessor.
+	if _, err := f.WriteString(`; Copyright 2018 The BoringSSL Authors
+;
+; Permission to use, copy, modify, and/or distribute this software for any
+; purpose with or without fee is hereby granted, provided that the above
+; copyright notice and this permission notice appear in all copies.
+;
+; THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+; WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+; MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+; SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+; OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+; CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+; 32-bit Windows adds underscores to C functions, while 64-bit Windows does not.
+%ifidn __OUTPUT_FORMAT__, win32
+`); err != nil {
+		return err
+	}
+
+	for _, symbol := range symbols {
+		if _, err := fmt.Fprintf(f, "%%xdefine _%s _ %%+ BORINGSSL_PREFIX %%+ _%s\n", symbol, symbol); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(f, "%%else\n"); err != nil {
+		return err
+	}
+
+	for _, symbol := range symbols {
+		if _, err := fmt.Fprintf(f, "%%xdefine %s BORINGSSL_PREFIX %%+ _%s\n", symbol, symbol); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(f, "%%endif\n"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s [-out OUT] SYMBOLS\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	symbols, err := readSymbols(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading symbols: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeCHeader(symbols, filepath.Join(*out, "boringssl_prefix_symbols.h")); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing boringssl_prefix_symbols.h: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeASMHeader(symbols, filepath.Join(*out, "boringssl_prefix_symbols_asm.h")); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing boringssl_prefix_symbols_asm.h: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeNASMHeader(symbols, filepath.Join(*out, "boringssl_prefix_symbols_nasm.inc")); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing boringssl_prefix_symbols_nasm.inc: %s\n", err)
+		os.Exit(1)
+	}
+
+}

--- a/scripts/vendored-util/read_symbols.go
+++ b/scripts/vendored-util/read_symbols.go
@@ -1,0 +1,267 @@
+// Copyright 2018 The BoringSSL Authors
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+//go:build ignore
+
+// read_symbols scans one or more .a files and, for each object contained in
+// the .a files, reads the list of symbols in that object file.
+package main
+
+import (
+	"bytes"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+
+	"boringssl.googlesource.com/boringssl.git/util/ar"
+)
+
+const (
+	ObjFileFormatELF   = "elf"
+	ObjFileFormatMachO = "macho"
+	ObjFileFormatPE    = "pe"
+)
+
+var (
+	outFlag       = flag.String("out", "-", "File to write output symbols")
+	objFileFormat = flag.String("obj-file-format", defaultObjFileFormat(runtime.GOOS), "Object file format to expect (options are elf, macho, pe)")
+)
+
+func defaultObjFileFormat(goos string) string {
+	switch goos {
+	case "linux":
+		return ObjFileFormatELF
+	case "darwin":
+		return ObjFileFormatMachO
+	case "windows":
+		return ObjFileFormatPE
+	default:
+		// By returning a value here rather than panicking, the user can still
+		// cross-compile from an unsupported platform to a supported platform by
+		// overriding this default with a flag. If the user doesn't provide the
+		// flag, we will panic during flag parsing.
+		return "unsupported"
+	}
+}
+
+func printAndExit(format string, args ...any) {
+	s := fmt.Sprintf(format, args...)
+	fmt.Fprintln(os.Stderr, s)
+	os.Exit(1)
+}
+
+func main() {
+	flag.Parse()
+	if flag.NArg() < 1 {
+		printAndExit("Usage: %s [-out OUT] [-obj-file-format FORMAT] ARCHIVE_FILE [ARCHIVE_FILE [...]]", os.Args[0])
+	}
+	archiveFiles := flag.Args()
+
+	out := os.Stdout
+	if *outFlag != "-" {
+		var err error
+		out, err = os.Create(*outFlag)
+		if err != nil {
+			printAndExit("Error opening %q: %s", *outFlag, err)
+		}
+		defer out.Close()
+	}
+
+	var symbols []string
+	// Only add first instance of any symbol; keep track of them in this map.
+	added := make(map[string]struct{})
+	for _, archive := range archiveFiles {
+		f, err := os.Open(archive)
+		if err != nil {
+			printAndExit("Error opening %s: %s", archive, err)
+		}
+		objectFiles, err := ar.ParseAR(f)
+		f.Close()
+		if err != nil {
+			printAndExit("Error parsing %s: %s", archive, err)
+		}
+
+		for name, contents := range objectFiles {
+			syms, err := listSymbols(contents)
+			if err != nil {
+				printAndExit("Error listing symbols from %q in %q: %s", name, archive, err)
+			}
+			for _, s := range syms {
+				if _, ok := added[s]; !ok {
+					added[s] = struct{}{}
+					symbols = append(symbols, s)
+				}
+			}
+		}
+	}
+
+	sort.Strings(symbols)
+	for _, s := range symbols {
+		var skipSymbols = []string{
+			// Inline functions, etc., from the compiler or language
+			// runtime will naturally end up in the library, to be
+			// deduplicated against other object files. Such symbols
+			// should not be prefixed. It is a limitation of this
+			// symbol-prefixing strategy that we cannot distinguish
+			// our own inline symbols (which should be prefixed)
+			// from the system's (which should not), so we skip known
+			// system symbols.
+			"__local_stdio_printf_options",
+			"__local_stdio_scanf_options",
+			"_vscprintf",
+			"_vscprintf_l",
+			"_vsscanf_l",
+			"_xmm",
+			"sscanf",
+			"vsnprintf",
+			// sdallocx is a weak symbol and intended to merge with
+			// the real one, if present.
+			"sdallocx",
+		}
+		var skip bool
+		for _, sym := range skipSymbols {
+			if sym == s {
+				skip = true
+				break
+			}
+		}
+		if skip || isCXXSymbol(s) || strings.HasPrefix(s, "__real@") || strings.HasPrefix(s, "__x86.get_pc_thunk.") || strings.HasPrefix(s, "DW.") {
+			continue
+		}
+		if _, err := fmt.Fprintln(out, s); err != nil {
+			printAndExit("Error writing to %s: %s", *outFlag, err)
+		}
+	}
+}
+
+func isCXXSymbol(s string) bool {
+	if *objFileFormat == ObjFileFormatPE {
+		return strings.HasPrefix(s, "?")
+	}
+	return strings.HasPrefix(s, "_Z")
+}
+
+// listSymbols lists the exported symbols from an object file.
+func listSymbols(contents []byte) ([]string, error) {
+	switch *objFileFormat {
+	case ObjFileFormatELF:
+		return listSymbolsELF(contents)
+	case ObjFileFormatMachO:
+		return listSymbolsMachO(contents)
+	case ObjFileFormatPE:
+		return listSymbolsPE(contents)
+	default:
+		return nil, fmt.Errorf("unsupported object file format %q", *objFileFormat)
+	}
+}
+
+func listSymbolsELF(contents []byte) ([]string, error) {
+	f, err := elf.NewFile(bytes.NewReader(contents))
+	if err != nil {
+		return nil, err
+	}
+	syms, err := f.Symbols()
+	if err == elf.ErrNoSymbols {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, sym := range syms {
+		// Only include exported, defined symbols
+		if elf.ST_BIND(sym.Info) != elf.STB_LOCAL && sym.Section != elf.SHN_UNDEF {
+			names = append(names, sym.Name)
+		}
+	}
+	return names, nil
+}
+
+func listSymbolsMachO(contents []byte) ([]string, error) {
+	f, err := macho.NewFile(bytes.NewReader(contents))
+	if err != nil {
+		return nil, err
+	}
+	if f.Symtab == nil {
+		return nil, nil
+	}
+	var names []string
+	for _, sym := range f.Symtab.Syms {
+		// Source: https://opensource.apple.com/source/xnu/xnu-3789.51.2/EXTERNAL_HEADERS/mach-o/nlist.h.auto.html
+		const (
+			N_PEXT uint8 = 0x10 // Private external symbol bit
+			N_EXT  uint8 = 0x01 // External symbol bit, set for external symbols
+			N_TYPE uint8 = 0x0e // mask for the type bits
+
+			N_UNDF uint8 = 0x0 // undefined, n_sect == NO_SECT
+			N_ABS  uint8 = 0x2 // absolute, n_sect == NO_SECT
+			N_SECT uint8 = 0xe // defined in section number n_sect
+			N_PBUD uint8 = 0xc // prebound undefined (defined in a dylib)
+			N_INDR uint8 = 0xa // indirect
+		)
+
+		// Only include exported, defined symbols.
+		if sym.Type&N_EXT != 0 && sym.Type&N_TYPE != N_UNDF {
+			if len(sym.Name) == 0 || sym.Name[0] != '_' {
+				return nil, fmt.Errorf("unexpected symbol without underscore prefix: %q", sym.Name)
+			}
+			names = append(names, sym.Name[1:])
+		}
+	}
+	return names, nil
+}
+
+func listSymbolsPE(contents []byte) ([]string, error) {
+	f, err := pe.NewFile(bytes.NewReader(contents))
+	if err != nil {
+		return nil, err
+	}
+	var ret []string
+	for _, sym := range f.Symbols {
+		const (
+			// https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#section-number-values
+			IMAGE_SYM_UNDEFINED = 0
+			// https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#storage-class
+			IMAGE_SYM_CLASS_EXTERNAL = 2
+		)
+		if sym.SectionNumber != IMAGE_SYM_UNDEFINED && sym.StorageClass == IMAGE_SYM_CLASS_EXTERNAL {
+			name := sym.Name
+			if f.Machine == pe.IMAGE_FILE_MACHINE_I386 {
+				// On 32-bit Windows, C symbols are decorated by calling
+				// convention.
+				// https://msdn.microsoft.com/en-us/library/56h2zst2.aspx#FormatC
+				if strings.HasPrefix(name, "_") || strings.HasPrefix(name, "@") {
+					// __cdecl, __stdcall, or __fastcall. Remove the prefix and
+					// suffix, if present.
+					name = name[1:]
+					if idx := strings.LastIndex(name, "@"); idx >= 0 {
+						name = name[:idx]
+					}
+				} else if idx := strings.LastIndex(name, "@@"); idx >= 0 {
+					// __vectorcall. Remove the suffix.
+					name = name[:idx]
+				}
+			}
+			ret = append(ret, name)
+		}
+	}
+	return ret, nil
+}


### PR DESCRIPTION
This PR contains the needed modifications for running the vendoring of boringssl from the tag `0.20260327.0`. The repo from `apple/swift-nio-ssl` is used as inspiration. Claude Code is used extensively in order to facilitate adapting scripts and sorting out necessary changes. The file `scripts/VENDORING-0.20260327.0.md` explains in detail the changes needed in order to vendor boringssl from said tag. I have read through all changes and attempted to verify generated code to the extent I understand. However, as this is quite complex, I'd love to get your take on the code @adam-fowler. Leaving this as a draft PR for now 

NB! This PR does not contain the vendored code as It would make the PR unmanageable. scripts/VENDORING-0.20260327.0.md explains how to build it. I have executed the script and the swift tests on my machine though, so it seems to be working.

